### PR TITLE
Stratus 730 add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM nginx:alpine
+
+WORKDIR /
+
+RUN apk add --no-cache nodejs yarn
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY package.json yarn.lock ./
+
+RUN yarn install --production
+RUN yarn set version berry
+
+COPY . ./
+RUN yarn build
+
+EXPOSE 8180
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,7 @@
 #https://github.com/statisticsnorway/dapla-react-reference-app/blob/master/Dockerfile
 FROM nginx:alpine
 
-RUN apk add --no-cache nodejs yarn
-
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY package.json yarn.lock ./
-
-RUN yarn install
-COPY . ./
-RUN yarn build
 
 COPY /build /usr/share/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
+#Inspired by https://codefresh.io/docs/docs/learn-by-example/nodejs/react/ and
+#https://github.com/statisticsnorway/dapla-react-reference-app/blob/master/Dockerfile
 FROM nginx:alpine
-
-WORKDIR /
 
 RUN apk add --no-cache nodejs yarn
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY package.json yarn.lock ./
 
-RUN yarn install --production
-RUN yarn set version berry
-
+RUN yarn install
 COPY . ./
 RUN yarn build
+
+COPY /build /usr/share/nginx/html
 
 EXPOSE 8180
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
-#### `yarn start`
+* `yarn up` (will upgrade all packages; must be done before running first time)
+* `yarn start`
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -59,6 +60,16 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+### Build container
+
+Podman or docker:
+`docker build . -t bip-start:0.1.0`
+
+### Run container locally
+
+Podman or docker:
+`docker run -p 8180:8180 localhost/bip-start:0.1.0`
 
 ### Learn More
 


### PR DESCRIPTION
bip-start needs a containerfile to enable creation of the container.
This change introduces this file and instructions for building and
running the container.

Internal ref: [STRATUS-730]

Co-authored-by: Lisa <35797988+lisawolderiksen@users.noreply.github.com>

[STRATUS-730]: https://statistics-norway.atlassian.net/browse/STRATUS-730