### PR TITLE
Create our own pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,35 +1,101 @@
 name: $(Build.SourceBranch)-$(date:yyyyMMdd)$(rev:.r)
 
+# This pipeline is inspired by the template 
+# https://github.com/statisticsnorway/azure-pipelines-templates/blob/master/javascript/react-complete-build.yml
+
 trigger:
   branches:
     include:
       - master
 
-resources:
-  repositories:
-    - repository: templates
-      type: github
-      name: statisticsnorway/azure-pipelines-templates
-      # Locking to version/tag 1.1.22, update as new version tags for the repo are created 
-      ref: refs/tags/1.1.22
-      # endpoint: Name of service connection in team project in Az Pipelines
-      endpoint: github
-
 pool:
   vmImage: 'ubuntu-latest'
 
+variables:
+  - name: appName
+    value: 'bip-start'
+  - name: imageTag
+    value: '$(Build.SourceBranchName)-$(Build.SourceVersion)'
+  - name: teamname
+    value: 'stratus'
+  - name: sonarQubeServiceConnection
+    value: 'bipSonarQube'
+  - name: gcrServiceConnection
+    value: 'gcrServiceConnection'
+
 jobs:
-  - template: javascript/react-complete-build.yml@templates
-    # This template contains jobs for building code, building code + creating Docker image, and for tagging Docker image for production
-    # Ref. https://github.com/statisticsnorway/azure-pipelines-templates/blob/master/javascript/react-complete-build.yml 
-    parameters:
-      # appName is used to construct the path/name for the created Docker image
-      appName: 'bip-start'
-      # imageTag is used to tag the created Docker image: 'imagescan-${{ parameters.imageTag }}'
-      imageTag: '$(Build.SourceBranchName)-$(Build.SourceVersion)'
-      # namespace is used to construct the path for the created Docker image: 'prod-bip/ssb/${{ parameters.namespace }}/${{ parameters.appName }}'
-      namespace: 'stratus'
-      # tagToTag is used in conjunction with masterBranch to fetch & tag correct image when "tagging for prod"
-      tagToTag: '$(Build.SourceVersion)'
-      # masterBranch is used in conjunction with tagToTag to fetch & tag correct image when "tagging for prod"
-      masterBranch: 'master'
+  - job: pullRequest
+    displayName: 'Test, build, report test coverage, build & push Docker image, scan for vulns & retag image'
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    steps:
+      - script: |
+          set -e
+          yarn
+          CI=true yarn coverage
+          CI=true yarn build
+        displayName: 'Tests and build'
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
+      # There should be a code analysis tool step here, but for now SonarQube only works on master
+      # so there is a separate job to do the analysis based on master (i.e. not on PRs since they are on branches)
+      - task: Docker@2
+        displayName: 'Docker Build'
+        inputs:
+          repository: 'eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName)'
+          command: 'build'
+          Dockerfile: 'Dockerfile'
+          tags: 'imagescan-$(imageTag)'
+      - task: Docker@2
+        displayName: 'Docker Login'
+        inputs:
+          command: 'login'
+          containerRegistry: '$(gcrServiceConnection)'
+      - task: Docker@2
+        displayName: 'Docker Push'
+        inputs:
+          repository: 'prod-bip/ssb/$(teamname)/$(appName)'
+          command: 'push'
+          containerRegistry: '$(gcrServiceConnection)'
+          tags: 'imagescan-$(imageTag)'
+      - task: DownloadSecureFile@1
+        name: gcrJsonKey
+        inputs:
+          secureFile: 'gcr-key.json'
+      - script: |
+          echo "##vso[task.setvariable variable=GOOGLE_APPLICATION_CREDENTIALS]$(gcrJsonKey.secureFilePath)"
+        displayName: 'Set GCR Key'
+      - task: gcr-vulneralbility-check@1
+        inputs:
+          projectId: 'prod-bip'
+          imageHost: 'https://eu.gcr.io/'
+          image: 'prod-bip/ssb/$(teamname)/$(appName)'
+          imageTag: 'imagescan-$(imageTag)'
+          timeBetweenRetries: '10000'
+      - script: |
+          set -e
+          cat $(gcrJsonKey.secureFilePath) | docker login -u _json_key --password-stdin https://eu.gcr.io/
+          docker tag eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):imagescan-$(imageTag) eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):$(imageTag)
+          docker tag eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):imagescan-$(imageTag) eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):latest
+          docker push -a eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName)
+        displayName: 'Retag image after vuln scan'
+        condition: succeeded()
+  # For now, SonarQube can only be used on 'master' branch and hence cannot be run on PRs. 
+  # Therefore, we run it on merge to master. (Yes, a bit too late, but better than nothing.)
+  - job: sonarQubeMaster
+    displayName: 'Use SonarQube for code analysis'
+    # This condition combined with the "master branch" trigger for the pipeline, should ensure that
+    # this job only runs for the master branch
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    steps:
+      - task: SonarQubePrepare@4
+        inputs:
+          SonarQube: '$(sonarQubeServiceConnection)'
+          scannerMode: 'CLI'
+          configMode: 'manual'
+          cliProjectKey: $(Build.DefinitionName)
+          cliProjectName: $(Build.Repository.Name)
+          cliSources: '.'
+      - task: SonarQubeAnalyze@4
+      - task: SonarQubePublish@4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,8 @@ variables:
     value: 'gcrServiceConnection'
 
 jobs:
-  - job: pullRequest
+  - job: pullRequestOrMaster
     displayName: 'Test, build, report test coverage, build & push Docker image, scan for vulns & retag image'
-    condition: eq(variables['Build.Reason'], 'PullRequest')
     steps:
       - script: |
           set -e
@@ -35,11 +34,32 @@ jobs:
           CI=true yarn build
         displayName: 'Tests and build'
       - task: PublishCodeCoverageResults@1
+        displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'Cobertura'
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
-      # There should be a code analysis tool step here, but for now SonarQube only works on master
-      # so there is a separate job to do the analysis based on master (i.e. not on PRs since they are on branches)
+
+      - task: SonarQubePrepare@4
+        displayName: 'SonarQube prepare (unless PR)'
+        # For now, SonarQube can only be used on 'master' branch and hence cannot be run on PRs. 
+        # Therefore, we run it on merge to master. (Yes, a bit too late, but better than nothing.)
+        # This condition combined with the "master branch" trigger for the pipeline, should ensure that
+        # this task only runs for the master branch
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        inputs:
+          SonarQube: '$(sonarQubeServiceConnection)'
+          scannerMode: 'CLI'
+          configMode: 'manual'
+          cliProjectKey: $(Build.DefinitionName)
+          cliProjectName: $(Build.Repository.Name)
+          cliSources: '.'
+      - task: SonarQubeAnalyze@4
+        displayName: 'SonarQube analyze (unless PR)'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+      - task: SonarQubePublish@4
+        displayName: 'SonarQube publish (unless PR)'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+
       - task: Docker@2
         displayName: 'Docker Build'
         inputs:
@@ -60,6 +80,7 @@ jobs:
           containerRegistry: '$(gcrServiceConnection)'
           tags: 'imagescan-$(imageTag)'
       - task: DownloadSecureFile@1
+        displayName: 'Download GCR key'
         name: gcrJsonKey
         inputs:
           secureFile: 'gcr-key.json'
@@ -67,6 +88,7 @@ jobs:
           echo "##vso[task.setvariable variable=GOOGLE_APPLICATION_CREDENTIALS]$(gcrJsonKey.secureFilePath)"
         displayName: 'Set GCR Key'
       - task: gcr-vulneralbility-check@1
+        displayName: 'GCR image vuln check'
         inputs:
           projectId: 'prod-bip'
           imageHost: 'https://eu.gcr.io/'
@@ -79,23 +101,5 @@ jobs:
           docker tag eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):imagescan-$(imageTag) eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):$(imageTag)
           docker tag eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):imagescan-$(imageTag) eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName):latest
           docker push -a eu.gcr.io/prod-bip/ssb/$(teamname)/$(appName)
-        displayName: 'Retag image after vuln scan'
+        displayName: 'Retag image after vuln check'
         condition: succeeded()
-  # For now, SonarQube can only be used on 'master' branch and hence cannot be run on PRs. 
-  # Therefore, we run it on merge to master. (Yes, a bit too late, but better than nothing.)
-  - job: sonarQubeMaster
-    displayName: 'Use SonarQube for code analysis'
-    # This condition combined with the "master branch" trigger for the pipeline, should ensure that
-    # this job only runs for the master branch
-    condition: ne(variables['Build.Reason'], 'PullRequest')
-    steps:
-      - task: SonarQubePrepare@4
-        inputs:
-          SonarQube: '$(sonarQubeServiceConnection)'
-          scannerMode: 'CLI'
-          configMode: 'manual'
-          cliProjectKey: $(Build.DefinitionName)
-          cliProjectName: $(Build.Repository.Name)
-          cliSources: '.'
-      - task: SonarQubeAnalyze@4
-      - task: SonarQubePublish@4


### PR DESCRIPTION
The pipeline does "everything"* when a PR is created -
except for the SonarQube analysis, since that can only
be done on `master` branch (due to restrictions in our
version of SonarQube).

(*) Run tests & check coverage, build the app, build a
Docker image & tag it as "unscanned", runs the vuln-scan
task and tags the image as "scanned" if the scan task is
OK.

There is a separate job that handles the SonarQube
analysis, which is triggered by changes on `master`
branch, *except* for PRs. We might have to tweak this
a bit, as there might be cases I haven't thought about
where there are changes to the `master` branch that are
not PRs (and hence will trigger the SQ job even if it's
unneccessary or unwanted).

NOTE: 
If we decide to keep the pipeline like this, we have to change the HelmRelease to instruct Flux to check for images tagged with `merge-*` instead of `master-*`. We could update the pipeline to tag in a different way, but we might instead want to do the build & tag twice; once for PRs (just to get the checks) and once after merge to master (to get an image based on the new master + tagged with `master-<hash>` instead of `merge-<hash>`). 

Internal ref. [STRATUS-731]

[STRATUS-731]: https://statistics-norway.atlassian.net/browse/STRATUS-731