### PR TITLE
Add SonarQube config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,8 +53,6 @@ jobs:
           cliProjectKey: $(Build.DefinitionName)
           cliProjectName: $(Build.Repository.Name)
           cliSources: '.'
-          extraProperties: |
-            sonar.javascript.lcov.reportPaths=coverage/lcov.info
       - task: SonarQubeAnalyze@4
         displayName: 'SonarQube analyze (unless PR)'
         condition: ne(variables['Build.Reason'], 'PullRequest')

--- a/package.json
+++ b/package.json
@@ -58,11 +58,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**",
-      "!src/index.js",
-      "!src/**/index.js",
-      "!src/configurations/**",
-      "!src/enums/**",
-      "!src/__tests__/test-data/**"
+      "!**/index.js"
     ],
     "coverageReporters": [
       "cobertura",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.scm.disabled=true
+sonar.sources=src
+sonar.exclusions=**/node_modules/**, **/build/**, **/coverage/**
+sonar.test.exclusions=**/node_modules/**, **/build/**, **/coverage/**
+sonar.javascript.exclusions=**/node_modules/**, **/build/**, **/coverage/**
+sonar.cpd.exclusions=**/node_modules/**, **/build/**, **/coverage/**
+sonar.coverage.exclusions=**/node_modules/**, **/build/**, **/coverage/**, **/index.js, **/setupTests.js, **/reportWebVitals.js
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
SonarQube did not pick up on the code coverage when the
pipeline was run.
Now doing the same thing as in dapla-react-reference-app,
but with some config tweaked to match our setup.

Internal ref. [STRATUS-731]

[STRATUS-731]: https://statistics-norway.atlassian.net/browse/STRATUS-731