### PR TITLE
Add correct URL to the backend API in production

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL=http://localhost:5000/api/v1/generate
+REACT_APP_BACKEND_URL=https://bip-start.staging-bip-app.ssb.no/api/v1/generate


### PR DESCRIPTION
Why: The previuous commited changes contained an .env-file with the URL
to a local instance of bip-initializer.

How: The URL is corrected in the .env-file. This may be overridden
locally in a file named .env.local. This file will be ignored by GIT.

int.ref: [STRATUS-747]

[STRATUS-747]: https://statistics-norway.atlassian.net/browse/STRATUS-747