### PR TITLE
Fix backend url

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL=https://bip-start.staging-bip-app.ssb.no/api/v1/generate
+REACT_APP_BACKEND_URL=https://bip-initializer.staging-bip-app.ssb.no/api/v1/generate


### PR DESCRIPTION
The backend url for the frontend bip-start should be bip-initializer

Co-authored-by: are3k <5612258+are3k@users.noreply.github.com>
Co-authored-by: ssbwep <36296800+ssbwep@users.noreply.github.com>