### PR TITLE
Fix backend url... again

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL=https://bip-initializer.staging-bip-app.ssb.no/api/v1/generate
+REACT_APP_BACKEND_URL=https://bip-start.staging-bip-app.ssb.no/be/bip-initializer/api/v1/generate/


### PR DESCRIPTION
Slight misunderstanding of how calls to backends are done.
The form should be `<frontend>.<cluster>.ssb.no/be/<backend>`
We hope 🤞 

Co-authored-by: are3k <5612258+are3k@users.noreply.github.com>
Co-authored-by: ssbwep <36296800+ssbwep@users.noreply.github.com>