### PR TITLE
Add YAML-convertet output

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.21.1",
     "axios-hooks": "^2.6.3",
     "formik": "^2.2.9",
+    "js-yaml": "^4.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/__tests__/HRForm.test.js
+++ b/src/__tests__/HRForm.test.js
@@ -36,5 +36,6 @@ test('Renders data when backend call is ok', () => {
   useAxios.mockReturnValue([{ data: helmRelease, loading: false, error: undefined }, onSubmit])
   const { getByText } = setup()
 
-  expect(getByText(JSON.stringify(helmRelease))).toBeInTheDocument()
+  expect(getByText(/tag: main-8DFB94297F11440EB9B/)).toBeInTheDocument()
+  expect(getByText(/git: ssh:\/\/git@github.com\/statisticsnorway\/platform-dev/)).toBeInTheDocument()
 })

--- a/src/components/ResponseView.js
+++ b/src/components/ResponseView.js
@@ -4,9 +4,9 @@ function ResponseView ({ data }) {
   return (
     <div>
       <h2>Resultat</h2>
-      <p name='response'>
-        <pre>{yaml.dump(data, {indent: 2, sortKeys: true})}</pre>
-      </p>
+      <div name='response'>
+        <pre>{yaml.dump(data, { indent: 2, sortKeys: true })}</pre>
+      </div>
     </div>
   )
 }

--- a/src/components/ResponseView.js
+++ b/src/components/ResponseView.js
@@ -1,9 +1,11 @@
+import yaml from 'js-yaml'
+
 function ResponseView ({ data }) {
   return (
     <div>
       <h2>Resultat</h2>
       <p name='response'>
-        {JSON.stringify(data)}
+        <pre>{yaml.dump(data, {indent: 2, sortKeys: true})}</pre>
       </p>
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3300,6 +3300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 160b7a25d2a7097fd5fdf25eb8a99e037340078f70e6c7cfdef305837ed14d54570b2b13261bcae26c8cd44ad6e9a7136a0110d815ac65a7891c69c7bf2f4afd
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:^4.2.2":
   version: 4.2.2
   resolution: "aria-query@npm:4.2.2"
@@ -3959,6 +3966,7 @@ __metadata:
     axios: ^0.21.1
     axios-hooks: ^2.6.3
     formik: ^2.2.9
+    js-yaml: ^4.1.0
     react: ^17.0.2
     react-dom: ^17.0.2
     react-scripts: 4.0.3
@@ -9350,6 +9358,17 @@ fsevents@^1.2.7:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 46b61f889796a20d16b0b64580a01b6a02b2e45c1a2744906346da54d07e14cde764e887ab6d1512d8b2541c63711bd4b75859c28eb99605baf59fa173fc38c2
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 8973cf4296c944cc2551d1e3d3d064e7de0d0a6db3f7bafe40339ee9e5e0329560b52c4b8492b9b22365404c9be0822b62340ab49884e1dedfcc7ff80158abe0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Why: The API returns a JSON object containing the HelmReleas, and we
want to make it simple to copy this data into a YAML-file

How: Add package to hande YAML conversion and dumping

int.ref: [STRATUS-748]

Co-authored-by: ArielKarlsen <54323769+ArielKarlsen@users.noreply.github.com>
Co-authored-by: ssbwep <36296800+ssbwep@users.noreply.github.com>

[STRATUS-748]: https://statistics-norway.atlassian.net/browse/STRATUS-748