### PR TITLE
Add tooltips and improve formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/public/__ENV.js
 
 npm-debug.log*
 yarn-debug.log*

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>BIP-Start</title>
+    <title>BIP Initializer</title>
     <script src="%PUBLIC_URL%/__ENV.js"></script>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,10 @@
   color: white;
 }
 
+#hrform {
+  margin: 0.7em;
+}
+
 .App-link {
   color: #e5f0e6;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ function App () {
     <div className='App'>
       <header className='App-header'>
         <p>
-          Welcome to BIP-Start!
+          BIP Initializer
         </p>
 
       </header>

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -3,6 +3,6 @@ import App from '../App'
 
 test('renders welcome text', () => {
   render(<App />)
-  const titleText = screen.getByText(/Welcome to BIP-Start/i)
+  const titleText = screen.getByText(/BIP Initializer/i)
   expect(titleText).toBeInTheDocument()
 })

--- a/src/components/HRForm.js
+++ b/src/components/HRForm.js
@@ -16,7 +16,7 @@ const HRForm = () => {
   })
 
   return (
-    <div id="hrform">
+    <div id='hrform'>
       <Header as='h2'>Create HelmRelease</Header>
       <Formik
         initialValues={{
@@ -49,16 +49,18 @@ const HRForm = () => {
                   {value => <Label basic color='red' pointing='below'>{value}</Label>}
                 </ErrorMessage>
                 <Segment>
-                  
+
                   <Input
                     name='name'
                     label={
-                    <Label>Name
-                      <Popup trigger={<Icon name='info' color='green' size='small' circular />}
-                      content={helptextHRForm.name}
-                      position='top left'
-                      />
-                    </Label>}
+                      <Label>Name
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.name}
+                          position='top left'
+                        />
+                      </Label>
+}
                     placeholder={`${values.name}`}
                     onChange={handleChange}
                     error={errors.name && touched.name
@@ -74,11 +76,13 @@ const HRForm = () => {
                     name='namespace'
                     label={
                       <Label>Namespace
-                        <Popup trigger={<Icon name='info' color='green' size='small' circular />}
-                        content={helptextHRForm.namespace}
-                        position='top left'
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.namespace}
+                          position='top left'
                         />
-                      </Label>}
+                      </Label>
+}
                     placeholder={`${values.namespace}`}
                     onChange={handleChange}
                     error={errors.namespace && touched.namespace
@@ -102,21 +106,23 @@ const HRForm = () => {
                 </Segment>
                 <SegmentGroup horizontal>
                   <Segment>
-                    <Label attached='top'>Application Type<Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                    <Label attached='top'>Application Type<Popup
+                      trigger={<Icon name='info' color='green' size='small' circular />}
                       content={helptextHRForm.apptype}
                       position='top left'
-                      /></Label>
-                      <Field type='radio' name='appType' value='frontend' />
-                      <Label>Frontend</Label>
-                      <Field type='radio' name='appType' value='backend' />
-                      <Label>Backend</Label>
+                                                          />
+                    </Label>
+                    <Field type='radio' name='appType' value='frontend' />
+                    <Label>Frontend</Label>
+                    <Field type='radio' name='appType' value='backend' />
+                    <Label>Backend</Label>
                   </Segment>
                   <Segment>
                     <Label attached='top'>Cluster environment</Label>
-                      <Field type='radio' name='cluster' value='prod-bip-app' />
-                      <Label>Production</Label>
-                      <Field type='radio' name='cluster' value='staging-bip-ap' />
-                      <Label>Staging</Label>
+                    <Field type='radio' name='cluster' value='prod-bip-app' />
+                    <Label>Production</Label>
+                    <Field type='radio' name='cluster' value='staging-bip-ap' />
+                    <Label>Staging</Label>
                   </Segment>
                 </SegmentGroup>
               </Grid.Column>
@@ -167,10 +173,12 @@ const HRForm = () => {
                 </Segment>
                 <SegmentGroup horizontal>
                   <Segment textAlign='center'>
-                    <Label attached='top'>Exposed<Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                    <Label attached='top'>Exposed<Popup
+                      trigger={<Icon name='info' color='green' size='small' circular />}
                       content={helptextHRForm.exposed}
                       position='top left'
-                      /></Label>
+                                                 />
+                    </Label>
                     <Field type='checkbox' name='exposed' />
                   </Segment>
                   <Segment textAlign='center'>
@@ -188,7 +196,7 @@ const HRForm = () => {
                 </SegmentGroup>
               </Grid.Column>
               <Grid.Column width={16}>
-                  <Button fluid positive type='submit'>Submit</Button>
+                <Button fluid positive type='submit'>Submit</Button>
               </Grid.Column>
             </Grid>
           </Form>

--- a/src/components/HRForm.js
+++ b/src/components/HRForm.js
@@ -1,20 +1,23 @@
 import React from 'react'
-import { Button, Label, Grid, Segment, Input, SegmentGroup } from 'semantic-ui-react'
+import { Button, Label, Grid, Segment, Input, SegmentGroup, Header, Popup, Icon } from 'semantic-ui-react'
 import { Field, Form, Formik, ErrorMessage } from 'formik'
 import useAxios from 'axios-hooks'
 import ResponseView from './ResponseView'
 import { validationSchema } from './validationschema'
+import { helptextHRForm } from './helptext'
 
 const HRForm = () => {
   const [{ data, loading, error }, callGenerator] = useAxios({
     method: 'post',
     url: window.__ENV.REACT_APP_BE_GENERATE,
     timeout: 2500
+  }, {
+    manual: true
   })
 
   return (
-    <div>
-      <h1>Create HelmRelease</h1>
+    <div id="hrform">
+      <Header as='h2'>Create HelmRelease</Header>
       <Formik
         initialValues={{
           name: 'HelmReleasename',
@@ -40,17 +43,23 @@ const HRForm = () => {
 
         {({ handleChange, touched, errors, values }) => (
           <Form>
-            <Grid columns={2}>
+            <Grid stackable columns={2}>
               <Grid.Column>
                 <ErrorMessage name='name'>
                   {value => <Label basic color='red' pointing='below'>{value}</Label>}
                 </ErrorMessage>
                 <Segment>
+                  
                   <Input
                     name='name'
-                    label='Name'
+                    label={
+                    <Label>Name
+                      <Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                      content={helptextHRForm.name}
+                      position='top left'
+                      />
+                    </Label>}
                     placeholder={`${values.name}`}
-                    value={touched.name ? values.name : ''}
                     onChange={handleChange}
                     error={errors.name && touched.name
                       ? (<p class='error'>{errors.name}</p>)
@@ -63,9 +72,14 @@ const HRForm = () => {
                 <Segment>
                   <Input
                     name='namespace'
-                    label='Namespace'
+                    label={
+                      <Label>Namespace
+                        <Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                        content={helptextHRForm.namespace}
+                        position='top left'
+                        />
+                      </Label>}
                     placeholder={`${values.namespace}`}
-                    value={touched.namespace ? values.namespace : ''}
                     onChange={handleChange}
                     error={errors.namespace && touched.namespace
                       ? (<p class='error'>{errors.namespace}</p>)
@@ -80,7 +94,6 @@ const HRForm = () => {
                     name='billingproject'
                     label='Billing project'
                     placeholder={`${values.billingproject}`}
-                    value={touched.billingproject ? values.billingproject : ''}
                     onChange={handleChange}
                     error={errors.billingproject && touched.billingproject
                       ? (<p class='error'>{errors.billingproject}</p>)
@@ -89,22 +102,21 @@ const HRForm = () => {
                 </Segment>
                 <SegmentGroup horizontal>
                   <Segment>
-                    <Label attached='top left'>Application Type</Label>
-                    <div>
+                    <Label attached='top'>Application Type<Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                      content={helptextHRForm.apptype}
+                      position='top left'
+                      /></Label>
                       <Field type='radio' name='appType' value='frontend' />
-                      <label>Frontend</label>
+                      <Label>Frontend</Label>
                       <Field type='radio' name='appType' value='backend' />
-                      <label>Backend</label>
-                    </div>
+                      <Label>Backend</Label>
                   </Segment>
                   <Segment>
-                    <Label attached='top left'>Cluster environment</Label>
-                    <div>
+                    <Label attached='top'>Cluster environment</Label>
                       <Field type='radio' name='cluster' value='prod-bip-app' />
-                      <label>Production</label>
+                      <Label>Production</Label>
                       <Field type='radio' name='cluster' value='staging-bip-ap' />
-                      <label>Staging</label>
-                    </div>
+                      <Label>Staging</Label>
                   </Segment>
                 </SegmentGroup>
               </Grid.Column>
@@ -118,7 +130,6 @@ const HRForm = () => {
                     label='Container repository'
                     type='text'
                     placeholder={`${values.image_repository}${values.releaseName}`}
-                    value={touched.image_repository ? values.image_repository : ''}
                     onChange={handleChange}
                     error={errors.image_repository && touched.image_repository
                       ? (<p class='error'>{errors.image_repository}</p>)
@@ -133,7 +144,6 @@ const HRForm = () => {
                     name='flux_image_tag_pattern'
                     label='Tag pattern'
                     placeholder={`${values.flux_image_tag_pattern}`}
-                    value={touched.flux_image_tag_pattern ? values.flux_image_tag_pattern : ''}
                     onChange={handleChange}
                     error={errors.flux_image_tag_pattern && touched.flux_image_tag_pattern
                       ? (<p class='error'>{errors.flux_image_tag_pattern}</p>)
@@ -149,36 +159,36 @@ const HRForm = () => {
                     type='text'
                     label='Image tag'
                     placeholder={`${values.image_tag}`}
-                    value={touched.image_tag ? values.image_tag : ''}
                     onChange={handleChange}
                     error={errors.image_tag && touched.image_tag
                       ? (<p class='error'>{errors.image_tag}</p>)
                       : null}
                   />
-                </Segment>-
+                </Segment>
                 <SegmentGroup horizontal>
-                  <Segment>
-                    <Label attached='top left'>Exposed</Label>
+                  <Segment textAlign='center'>
+                    <Label attached='top'>Exposed<Popup trigger={<Icon name='info' color='green' size='small' circular />}
+                      content={helptextHRForm.exposed}
+                      position='top left'
+                      /></Label>
                     <Field type='checkbox' name='exposed' />
                   </Segment>
-                  <Segment>
-                    <Label attached='top left'>Authenticated</Label>
+                  <Segment textAlign='center'>
+                    <Label attached='top'>Authenticated</Label>
                     <Field type='checkbox' name='authentication' />
                   </Segment>
-                  <Segment>
-                    <Label attached='top left'>Health probes</Label>
+                  <Segment textAlign='center'>
+                    <Label attached='top'>Health probes</Label>
                     <Field type='checkbox' name='health_probes' />
                   </Segment>
-                  <Segment>
-                    <Label attached='top left'>Collect metrics</Label>
+                  <Segment textAlign='center'>
+                    <Label attached='top'>Collect metrics</Label>
                     <Field type='checkbox' name='metrics' />
                   </Segment>
                 </SegmentGroup>
               </Grid.Column>
               <Grid.Column width={16}>
-                <Segment>
                   <Button fluid positive type='submit'>Submit</Button>
-                </Segment>
               </Grid.Column>
             </Grid>
           </Form>

--- a/src/components/ResponseView.js
+++ b/src/components/ResponseView.js
@@ -1,13 +1,14 @@
 import yaml from 'js-yaml'
+import {Header, Segment} from 'semantic-ui-react'
 
 function ResponseView ({ data }) {
   return (
-    <div>
-      <h2>Resultat</h2>
+    <Segment>
+      <Header as='h2'>Resultat</Header>
       <div name='response'>
         <pre>{yaml.dump(data, { indent: 2, sortKeys: true })}</pre>
       </div>
-    </div>
+    </Segment>
   )
 }
 

--- a/src/components/ResponseView.js
+++ b/src/components/ResponseView.js
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml'
-import {Header, Segment} from 'semantic-ui-react'
+import { Header, Segment } from 'semantic-ui-react'
 
 function ResponseView ({ data }) {
   return (

--- a/src/components/helptext.js
+++ b/src/components/helptext.js
@@ -1,6 +1,6 @@
 export const helptextHRForm = {
-  'name'     : 'This is the name of the \'HelmRelease\' object. It is a good practice that this matches the name of the Helm release itself (i.e. \'spec.releaseName\')',
-  'namespace': 'Often the team name',
-  'apptype'  : 'The type of application to set up. We currently support \'frontend\' and \'backend\'. We set up things automatically based on what you choose here, so remember to use the correct type. A \'backend\' application will',
-  'exposed'  : 'This will expose the application as \'<name>.<cluster>.<domain>\'. In this case, the app will be exposed as \'podinfo.staging-bip-app.ssb.no\'. To be able to expose an app, the cluster needs to run Istio (which is normally the default). Default value is \'false\''
+  name: 'This is the name of the \'HelmRelease\' object. It is a good practice that this matches the name of the Helm release itself (i.e. \'spec.releaseName\')',
+  namespace: 'Often the team name',
+  apptype: 'The type of application to set up. We currently support \'frontend\' and \'backend\'. We set up things automatically based on what you choose here, so remember to use the correct type. A \'backend\' application will',
+  exposed: 'This will expose the application as \'<name>.<cluster>.<domain>\'. In this case, the app will be exposed as \'podinfo.staging-bip-app.ssb.no\'. To be able to expose an app, the cluster needs to run Istio (which is normally the default). Default value is \'false\''
 }

--- a/src/components/helptext.js
+++ b/src/components/helptext.js
@@ -1,0 +1,6 @@
+export const helptextHRForm = {
+  'name'     : 'This is the name of the \'HelmRelease\' object. It is a good practice that this matches the name of the Helm release itself (i.e. \'spec.releaseName\')',
+  'namespace': 'Often the team name',
+  'apptype'  : 'The type of application to set up. We currently support \'frontend\' and \'backend\'. We set up things automatically based on what you choose here, so remember to use the correct type. A \'backend\' application will',
+  'exposed'  : 'This will expose the application as \'<name>.<cluster>.<domain>\'. In this case, the app will be exposed as \'podinfo.staging-bip-app.ssb.no\'. To be able to expose an app, the cluster needs to run Istio (which is normally the default). Default value is \'false\''
+}


### PR DESCRIPTION
Why: The form didn't react as wanted, some aliging was necessary, and
we needed to include tooltip popups to give extended information about
some of the fields in form.

How: We added some more elements from Semantic-ui-react and created a
data structure for helptexts that can be shown in popup tooltips.

int.ref: [STRATUS-748]

Co-authored-by: ArielKarlsen <54323769+ArielKarlsen@users.noreply.github.com>
Co-authored-by: ssbwep <36296800+ssbwep@users.noreply.github.com>

[STRATUS-748]: https://statistics-norway.atlassian.net/browse/STRATUS-748