### PR TITLE
Bug fix image repo & improved helptext

### DIFF
--- a/src/components/HRForm.js
+++ b/src/components/HRForm.js
@@ -20,12 +20,12 @@ const HRForm = () => {
       <Header as='h2'>Create HelmRelease</Header>
       <Formik
         initialValues={{
-          name: 'HelmReleasename',
+          name: 'HelmReleaseName',
           namespace: 'Teamname',
           billingproject: 'Sirius',
           appType: 'frontend',
           cluster: 'prod-bip-app',
-          image_repository: 'https://eu.gcr.io/prod-bip/ssb/',
+          image_repository: 'eu.gcr.io/prod-bip/ssb/',
           flux_image_tag_pattern: 'glob:master-*',
           image_tag: 'Initial image tag',
           exposed: false,
@@ -59,8 +59,9 @@ const HRForm = () => {
                           content={helptextHRForm.name}
                           position='top left'
                         />
-                      </Label>}
-                    style={{width: "100%"}}
+                      </Label>
+                    }
+                    style={{ width: '100%' }}
                     placeholder={`${values.name}`}
                     onChange={handleChange}
                     error={errors.name && touched.name
@@ -81,8 +82,9 @@ const HRForm = () => {
                           content={helptextHRForm.namespace}
                           position='top left'
                         />
-                      </Label>}
-                    style={{width: "100%"}}
+                      </Label>
+                    }
+                    style={{ width: '100%' }}
                     placeholder={`${values.namespace}`}
                     onChange={handleChange}
                     error={errors.namespace && touched.namespace
@@ -96,8 +98,16 @@ const HRForm = () => {
                 <Segment>
                   <Input
                     name='billingproject'
-                    label='Billing project'
-                    style={{width: "100%"}}
+                    label={
+                      <Label>Billing project
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.billingproject}
+                          position='top left'
+                        />
+                      </Label>
+                    }
+                    style={{ width: '100%' }}
                     placeholder={`${values.billingproject}`}
                     onChange={handleChange}
                     error={errors.billingproject && touched.billingproject
@@ -107,10 +117,12 @@ const HRForm = () => {
                 </Segment>
                 <SegmentGroup horizontal>
                   <Segment>
-                    <Label attached='top'>Application Type<Popup
-                      trigger={<Icon name='info' color='green' size='small' circular />}
-                      content={helptextHRForm.apptype}
-                      position='top left'/>
+                    <Label attached='top'>Application Type
+                      <Popup
+                        trigger={<Icon name='info' color='green' size='small' circular />}
+                        content={helptextHRForm.apptype}
+                        position='top left'
+                      />
                     </Label>
                     <Field type='radio' name='appType' value='frontend' />
                     <Label>Frontend</Label>
@@ -118,7 +130,13 @@ const HRForm = () => {
                     <Label>Backend</Label>
                   </Segment>
                   <Segment>
-                    <Label attached='top'>Cluster environment</Label>
+                    <Label attached='top'>Cluster environment
+                      <Popup
+                        trigger={<Icon name='info' color='green' size='small' circular />}
+                        content={helptextHRForm.cluster}
+                        position='top left'
+                      />
+                    </Label>
                     <Field type='radio' name='cluster' value='prod-bip-app' />
                     <Label>Production</Label>
                     <Field type='radio' name='cluster' value='staging-bip-ap' />
@@ -133,9 +151,17 @@ const HRForm = () => {
                 <Segment>
                   <Input
                     name='image_repository'
-                    label='Container repository'
+                    label={
+                      <Label>Container repository
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.containerrepo}
+                          position='top left'
+                        />
+                      </Label>
+                    }
                     type='text'
-                    style={{width: "100%"}}
+                    style={{ width: '100%' }}
                     placeholder={`${values.image_repository}${values.releaseName}`}
                     onChange={handleChange}
                     error={errors.image_repository && touched.image_repository
@@ -149,8 +175,16 @@ const HRForm = () => {
                 <Segment>
                   <Input
                     name='flux_image_tag_pattern'
-                    label='Tag pattern'
-                    style={{width: "100%"}}
+                    label={
+                      <Label>Tag pattern
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.tagpattern}
+                          position='top left'
+                        />
+                      </Label>
+                    }
+                    style={{ width: '100%' }}
                     placeholder={`${values.flux_image_tag_pattern}`}
                     onChange={handleChange}
                     error={errors.flux_image_tag_pattern && touched.flux_image_tag_pattern
@@ -165,8 +199,16 @@ const HRForm = () => {
                   <Input
                     name='image_tag'
                     type='text'
-                    label='Image tag'
-                    style={{width: "100%"}}
+                    label={
+                      <Label>Image tag
+                        <Popup
+                          trigger={<Icon name='info' color='green' size='small' circular />}
+                          content={helptextHRForm.imagetag}
+                          position='top left'
+                        />
+                      </Label>
+                    }
+                    style={{ width: '100%' }}
                     placeholder={`${values.image_tag}`}
                     onChange={handleChange}
                     error={errors.image_tag && touched.image_tag
@@ -176,10 +218,12 @@ const HRForm = () => {
                 </Segment>
                 <SegmentGroup horizontal>
                   <Segment textAlign='center'>
-                    <Label attached='top'>Exposed<Popup
-                      trigger={<Icon name='info' color='green' size='small' circular />}
-                      content={helptextHRForm.exposed}
-                      position='top left'/>
+                    <Label attached='top'>Exposed
+                      <Popup
+                        trigger={<Icon name='info' color='green' size='small' circular />}
+                        content={helptextHRForm.exposed}
+                        position='top left'
+                      />
                     </Label>
                     <Field type='checkbox' name='exposed' />
                   </Segment>
@@ -192,7 +236,13 @@ const HRForm = () => {
                     <Field type='checkbox' name='health_probes' />
                   </Segment>
                   <Segment textAlign='center'>
-                    <Label attached='top'>Collect metrics</Label>
+                    <Label attached='top'>Collect metrics
+                      <Popup
+                        trigger={<Icon name='info' color='green' size='small' circular />}
+                        content={helptextHRForm.metrics}
+                        position='top left'
+                      />
+                    </Label>
                     <Field type='checkbox' name='metrics' />
                   </Segment>
                 </SegmentGroup>

--- a/src/components/ResponseView.js
+++ b/src/components/ResponseView.js
@@ -6,8 +6,10 @@ function ResponseView ({ data, allOK }) {
     return (
       <Segment>
         <Header as='h2'>Generated HelmRelease</Header>
-        <p>Copy the following HelmRelease to a text file, eg. name.yaml<br />
-        This file should be checked in to the platform-dev git repository.</p>
+        <p>
+          Copy the following HelmRelease to a text file, eg. name.yaml<br />
+          This file should be checked in to the platform-dev git repository.
+        </p>
         <div name='response'>
           <pre>{yaml.dump(data, { indent: 2, sortKeys: true })}</pre>
         </div>

--- a/src/components/helptext.js
+++ b/src/components/helptext.js
@@ -1,6 +1,12 @@
 export const helptextHRForm = {
-  name: 'This is the name of the \'HelmRelease\' object. It is a good practice that this matches the name of the Helm release itself (i.e. \'spec.releaseName\')',
-  namespace: 'Often the team name',
-  apptype: 'The type of application to set up. We currently support \'frontend\' and \'backend\'. We set up things automatically based on what you choose here, so remember to use the correct type. A \'backend\' application will',
-  exposed: 'This will expose the application as \'<name>.<cluster>.<domain>\'. In this case, the app will be exposed as \'podinfo.staging-bip-app.ssb.no\'. To be able to expose an app, the cluster needs to run Istio (which is normally the default). Default value is \'false\''
+  name: 'This is the name of the \'HelmRelease\' object',
+  namespace: 'The namespace where this will be deployed. Usually the same name as the team name',
+  billingproject: 'This is used to be able to see the cloud cost for a team. It is important to set this consistently for all team apps',
+  apptype: 'The type of application to set up. We currently support \'frontend\' and \'backend\'. We set up things automatically based on what you choose here, so remember to use the correct type',
+  cluster: 'The Kubernetes cluster this application will be deployed to',
+  containerrepo: 'Where the Docker image is located. Usually \'eu.gcr.io/prod-bip/<name>\' for SSB applications',
+  tagpattern: 'The pattern of the tag used to find what images to deploy automatically. The filter can either be a glob, semver or regex pattern. \'glob:master-*\' is a common pattern used to deploy all new images on the master branch',
+  imagetag: 'The tag of the Docker image that is to be deployed',
+  exposed: 'Enale this will expose the application as \'<name>.<cluster>.<domain>\'',
+  metrics: 'Enable this to let Prometheus collect metrics from the application\'s \'/metrics\' endpoint'
 }

--- a/src/components/validationschema.js
+++ b/src/components/validationschema.js
@@ -25,9 +25,6 @@ export const validationSchema = Yup.object({
       .max(128, 'Max length: 128 characters')
       .required('Required field')
       .matches(qFluxImageTagFmt, 'Value must match RegEx: ' + qFluxImageTagFmt),
-  image_repository:
-    Yup.string()
-      .url('Value must be a well formed URL'),
   image_tag:
     Yup.string()
       .max(128, 'Max length: 128 characters')

--- a/src/components/validationschema.js
+++ b/src/components/validationschema.js
@@ -3,6 +3,7 @@ import * as Yup from 'yup'
 const qnameCharFmt = '^[A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9])?$'
 const qImageTagFmt = '^[a-zA-Z0-9][-a-zA-Z0-9._*]*$'
 const qFluxImageTagFmt = '^(glob|regex|semver):[a-zA-Z0-9][-a-zA-Z0-9._*]*$'
+const qurlFmt = '^(https?://)?(www.)?[a-zA-Z0-9]+([-a-zA-Z0-9.]{1,254}[A-Za-z0-9])?.[a-zA-Z0-9()]{1,6}([/][-a-zA-Z0-9_]+)*[/]?'
 
 export const validationSchema = Yup.object({
   name:
@@ -25,6 +26,9 @@ export const validationSchema = Yup.object({
       .max(128, 'Max length: 128 characters')
       .required('Required field')
       .matches(qFluxImageTagFmt, 'Value must match RegEx: ' + qFluxImageTagFmt),
+  image_repository:
+    Yup.string()
+      .matches(qurlFmt, 'Value must match RegEx' + qurlFmt),
   image_tag:
     Yup.string()
       .max(128, 'Max length: 128 characters')


### PR DESCRIPTION
The image repository field in bip-start requires 'http' prefix. This is
not valid when the helmrelease is deployed to the application clusters.
Therefore urls without https should be allowed.
As for now the validation of the image repository field is removed, but
could be reintroduced with a custom regular expression to reflect how
we want the url to look like.

Additionally, the helptexts for the fields have been improved and
more texts have been added. The origin of most of these texts can be found here:
https://github.com/statisticsnorway/platform-dev/blob/master/flux/cluster1/team1/podinfo/podinfo.yaml

This PR also includes some syntax fixes.