### PR TITLE
Fix typo in cluster environment

### DIFF
--- a/src/components/HRForm.js
+++ b/src/components/HRForm.js
@@ -139,7 +139,7 @@ const HRForm = () => {
                     </Label>
                     <Field type='radio' name='cluster' value='prod-bip-app' />
                     <Label>Production</Label>
-                    <Field type='radio' name='cluster' value='staging-bip-ap' />
+                    <Field type='radio' name='cluster' value='staging-bip-app' />
                     <Label>Staging</Label>
                   </Segment>
                 </SegmentGroup>


### PR DESCRIPTION
This PR contains a simple typo fix for the cluster environment
staging-bip-app.

The typo caused the generated HR to include 'staging-bip-ap' in the HR
instead of 'staging-bip-app'