### PR TITLE
Add Github action to analyse in Sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,5 @@
+sonar.projectKey=statisticsnorway_bip-start
+sonar.organization=statisticsnorway
 sonar.scm.disabled=true
 sonar.sources=src
 sonar.exclusions=**/node_modules/**, **/build/**, **/coverage/**


### PR DESCRIPTION
Why: We need to test Sonarcloud to develop a good way to include
Sonarcloud into the CI process.

How: Add necessary files to configure Github actions

int.ref: [STRATUS-304]

Co-authored-by: ssbwep <36296800+ssbwep@users.noreply.github.com>

[STRATUS-304]: https://statistics-norway.atlassian.net/browse/STRATUS-304